### PR TITLE
Allow server to run "insecurely"

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,5 @@ CERT_DIR=</path/to/cert/root>
 sudo chmod 755 -R $CERT_DIR/archive $CERT_DIR/live
 ```
 - remove forwarding of port 80?
+
+*reminder:* may need to change port forwarding settings on both modem and router. Xfinity modem settings can be changed [here](https://internet.xfinity.com/network/advanced-settings/portforwarding).

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
-cxxopts/[>=2.2.0]
-fmt/[>=7.0.3]
+cxxopts/[>=2.2.1]
+fmt/[>=7.1.3]
 nlohmann_json/[>=3.9.1]
 websocketpp/[>= 0.8.2]
 

--- a/src/ClientInfo.h
+++ b/src/ClientInfo.h
@@ -16,9 +16,9 @@ namespace websocket_server
 
     void assign_room(const room_id_type &room);
 
-    const room_id_type &room() const;
-    const client_id_type &id() const;
-    bool unassigned() const;
+    [[nodiscard]] const room_id_type &room() const;
+    [[nodiscard]] const client_id_type &id() const;
+    [[nodiscard]] bool unassigned() const;
 
   private:
     room_id_type room_;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,9 @@ websocket_server::Parameters parse_arguments(int argc, char **argv)
     options.add_options()("verbose",
                           "If true, server will print verbose debugging information to the console.",
                           cxxopts::value<decltype(Parameters::verbose)>(params.verbose)->default_value("false"));
+    options.add_options()("insecure",
+                          "If true, application will host an insecure server. Should only be used for local debugging.",
+                          cxxopts::value<decltype(Parameters::insecure)>(params.insecure)->default_value("false"));
 
     auto result = options.parse(argc, argv);
 
@@ -52,8 +55,11 @@ websocket_server::Parameters parse_arguments(int argc, char **argv)
       print_help();
     }
 
-    handle_required_argument("certfile");
-    handle_required_argument("keyfile");
+    if (!params.insecure)
+    {
+      handle_required_argument("certfile");
+      handle_required_argument("keyfile");
+    }
   }
   catch (const cxxopts::OptionException &e)
   {

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -39,21 +39,42 @@ namespace websocket_server
   constexpr auto peer_id_key      = "peer_id";
   constexpr auto data_key         = "content";
 
-  WSS::WSS(const Parameters &params) : run_debug_logger_(params.verbose)
+  WSS::WSS(const Parameters &params) : run_debug_logger_(params.verbose), insecure_(params.insecure)
   {
     using websocketpp::lib::bind;
 
-    server_.init_asio();
-    server_.set_reuse_addr(true);
+    if (insecure_)
+    {
+      server_.emplace<insecure_server_type>();
+    }
+    else
+    {
+      server_.emplace<secure_server_type>();
+    }
 
-    server_.set_message_handler([this](auto handle, auto message) { message_handler(handle, message); });
-    server_.set_http_handler([this](auto handle) { http_handler(handle); });
-    server_.set_close_handler([this](auto handle) { remove_client_from_room(handle); });
-    server_.set_tls_init_handler(
-        [this, params](auto handle) { return tls_init_handler(handle, params.key_file, params.cert_file); });
+    std::visit([](auto &&server) { server.init_asio(); }, server_);
+    std::visit([](auto &&server) { server.set_reuse_addr(true); }, server_);
 
-    server_.listen(params.port);
-    server_.start_accept();
+    std::visit(
+        [this](auto &&server) {
+          server.set_message_handler([this](auto handle, auto message) { message_handler(handle, message); });
+        },
+        server_);
+    std::visit([this](auto &&server) { server.set_http_handler([this](auto handle) { http_handler(handle); }); }, server_);
+    std::visit([this](auto &&server) { server.set_close_handler([this](auto handle) { remove_client_from_room(handle); }); },
+               server_);
+    std::visit(
+        [this, params](auto &&server) {
+          if constexpr (std::is_same_v<std::decay_t<decltype(server)>, secure_server_type>)
+          {
+            server.set_tls_init_handler(
+                [this, params](auto handle) { return tls_init_handler(handle, params.key_file, params.cert_file); });
+          }
+        },
+        server_);
+
+    std::visit([port = params.port](auto &&server) { server.listen(port); }, server_);
+    std::visit([](auto &&server) { server.start_accept(); }, server_);
 
     if (params.verbose)
     {
@@ -94,12 +115,12 @@ namespace websocket_server
       fmt::print(fg(fmt::color::cyan), "starting server.\n");
     }
 
-    server_.run();
+    std::visit([](auto &&server) { server.run(); }, server_);
   }
 
   void WSS::message_handler(connection_type handle, message_pointer_type message)
   {
-    auto connection = server_.get_con_from_hdl(handle);
+    // auto connection = std::visit([handle](auto &&server) { return server.get_con_from_hdl(handle); }, server_);
 
     auto parsed_data = json::parse(message->get_payload());
 
@@ -121,7 +142,7 @@ namespace websocket_server
     {
       if (current_client != peer)
       {
-        server_.send(*peer, message);
+        std::visit([peer, message](auto &&server) { server.send(*peer, message); }, server_);
       }
     }
   }
@@ -142,12 +163,14 @@ namespace websocket_server
       json client_reply_message = {{peer_id_key, client_mapping_[handle].id()},
                                    {message_type_key, message_type_to_string.at(MessageType::SERVER)},
                                    {data_key, "your id"}};
-      server_.send(handle, client_reply_message.dump(), websocketpp::frame::opcode::TEXT);
+      std::visit([handle, client_reply_message](
+                     auto &&server) { server.send(handle, client_reply_message.dump(), websocketpp::frame::opcode::TEXT); },
+                 server_);
 
       if (run_debug_logger_)
       {
-        auto connection = server_.get_con_from_hdl(handle);
-        auto uuid       = client_mapping_[handle].id();
+        // auto connection = std::visit([handle](auto &&server) { return server.get_con_from_hdl(handle); }, server_);
+        auto uuid = client_mapping_[handle].id();
 
         fmt::print(fg(fmt::color::dark_turquoise), "Added connection: [room: {}, uuid: {}]\n", room_id, uuid);
 
@@ -183,7 +206,8 @@ namespace websocket_server
 
     for (auto peer = current_room.begin(); peer != current_room.end(); ++peer)
     {
-      server_.send(*peer, message.dump(), websocketpp::frame::opcode::TEXT);
+      std::visit([peer, message](auto &&server) { server.send(*peer, message.dump(), websocketpp::frame::opcode::TEXT); },
+                 server_);
     }
 
     auto room_closed = close_if_empty(room_id);
@@ -202,9 +226,12 @@ namespace websocket_server
 
   void WSS::http_handler(connection_type handle)
   {
-    auto connection = server_.get_con_from_hdl(handle);
-
-    connection->set_status(websocketpp::http::status_code::accepted);
+    std::visit(
+        [handle](auto &&server) {
+          auto connection = server.get_con_from_hdl(handle);
+          connection->set_status(websocketpp::http::status_code::accepted);
+        },
+        server_);
   }
 
   WSS::tls_context_pointer_type WSS::tls_init_handler(connection_type handle, const fs::path &keyfile, const fs::path &certfile)

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -186,9 +186,9 @@ namespace websocket_server
     constexpr auto uuid_key       = peer_id_key;
     constexpr auto delete_message = "delete";
 
-    const auto &client = client_mapping_.at(handle);
-    auto client_uuid   = std::move(client.id());
-    auto room_id       = std::move(client.room());
+    const auto &client      = client_mapping_.at(handle);
+    const auto &client_uuid = client.id();
+    const auto &room_id     = client.room();
 
     json message = {
         {uuid_key, client_uuid}, {message_type_key, message_type_to_string.at(MessageType::SERVER)}, {data_key, delete_message}};

--- a/src/server.hpp
+++ b/src/server.hpp
@@ -12,6 +12,7 @@
 #include <set>
 #include <thread>
 #include <unordered_map>
+#include <variant>
 
 namespace websocket_server
 {
@@ -25,6 +26,7 @@ namespace websocket_server
     fs::path key_file;
 
     bool verbose;
+    bool insecure;
   };
 
   class WSS
@@ -38,7 +40,9 @@ namespace websocket_server
     using connection_type = websocketpp::connection_hdl;
 
   private:
-    using server_type              = websocketpp::server<websocketpp::config::asio_tls>;
+    using insecure_server_type     = websocketpp::server<websocketpp::config::asio>;
+    using secure_server_type       = websocketpp::server<websocketpp::config::asio_tls>;
+    using server_type              = std::variant<insecure_server_type, secure_server_type>;
     using connection_comparator    = std::owner_less<connection_type>;
     using tls_context_type         = websocketpp::lib::asio::ssl::context;
     using tls_context_pointer_type = websocketpp::lib::shared_ptr<websocketpp::lib::asio::ssl::context>;
@@ -74,5 +78,6 @@ namespace websocket_server
 
     thread_type debug_logger_;
     std::atomic<bool> run_debug_logger_;
+    bool insecure_;
   };
 } // namespace websocket_server

--- a/src/server.hpp
+++ b/src/server.hpp
@@ -32,8 +32,14 @@ namespace websocket_server
   class WSS
   {
   public:
-    WSS(const Parameters &params);
+    explicit WSS(const Parameters &params);
     ~WSS();
+
+    // for now, disable copy and move semantics, because underlying websocketpp::server<> types provide neither ability.
+    WSS(const WSS &)     = delete;
+    WSS(WSS &&) noexcept = delete;
+    WSS &operator=(const WSS &) = delete;
+    WSS &operator=(WSS &&) noexcept = delete;
 
     void start();
 


### PR DESCRIPTION
Create a mode of operation without TLS. Should only be used for development testing, e.g. with localhost connections.